### PR TITLE
GH-4: FailOnSystemExit annotation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Todd Ginsberg
+Copyright (c) 2021 Todd Ginsberg
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -53,10 +53,23 @@ public class MyTestCases {
 }
 ```
 
-The `@ExpectSystemExit` and `@ExpectSystemExitWithStatus` annotations can be applied to methods, classs, or annotations (to act as meta-annotations).
+**A Test that should not expect `System.exit(1)` to be called, and fails the test if it does:**
+
+```java
+public class MyTestCases {
+    
+    @Test
+    @FailOnSystemExit
+    public void thisTestWillFail() {
+        System.exit(1);
+    }
+}
+```
+
+The `@ExpectSystemExit`, `@ExpectSystemExitWithStatus`, and `@FailOnSystemExit` annotations can be applied to methods, classes, or annotations (to act as meta-annotations).
 
 ## Contributing and Issues
 
 Please feel free to file issues for change requests or bugs. If you would like to contribute new functionality, please contact me first!
 
-Copyright &copy; 2018 by Todd Ginsberg
+Copyright &copy; 2021 by Todd Ginsberg

--- a/src/main/java/com/ginsberg/junit/exit/FailOnSystemExit.java
+++ b/src/main/java/com/ginsberg/junit/exit/FailOnSystemExit.java
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Todd Ginsberg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.ginsberg.junit.exit;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This is a marker annotation that indicates the given test method or class is not expected
+ * to call System.exit(). By annotating a test or a class with this annotation, we can prevent
+ * an inadvertent System.exit() call from tearing down the test infrastructure.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@ExtendWith(SystemExitExtension.class)
+public @interface FailOnSystemExit {
+
+}

--- a/src/test/java/com/ginsberg/junit/exit/FailOnSystemExitTest.java
+++ b/src/test/java/com/ginsberg/junit/exit/FailOnSystemExitTest.java
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Todd Ginsberg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.ginsberg.junit.exit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static com.ginsberg.junit.exit.TestUtils.assertTestFails;
+
+class FailOnSystemExitTest {
+
+    @Test
+    @DisplayName("@FailOnSystemExit on method - exception caught and fails test")
+    void failOnSystemExitOnMethod() {
+        assertTestFails(FailOnSystemExitAtTestLevel.class, "callsSystemExit");
+    }
+
+    @Test
+    @DisplayName("@FailOnSystemExit on class - exception caught and fails test")
+    void failOnSystemExitOnClass() {
+        assertTestFails(FailOnSystemExitAtClassLevel.class);
+    }
+
+    @EnabledIfSystemProperty(named = "running_within_test", matches = "true")
+    static class FailOnSystemExitAtTestLevel {
+        @Test
+        @FailOnSystemExit
+        void callsSystemExit() {
+            System.exit(42);
+        }
+    }
+
+    @EnabledIfSystemProperty(named = "running_within_test", matches = "true")
+    @FailOnSystemExit
+    static class FailOnSystemExitAtClassLevel {
+        @Test
+        void callsSystemExit() {
+            System.exit(42);
+        }
+    }
+
+}


### PR DESCRIPTION
Add a new annotation to mark tests that should not call System.exit(), and rather than potentially allowing the JVM to exit, to mark the test as failed.

+ Add @FailOnSystemExit annotation
+ Update dates in License
+ Update README