### PR TITLE
Fix #20 - Multiple calls to `System.exit()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log for `junit5-system-exit`
 
 ### 2.0.1
-- TBD
+- Bugfix: [[#20]](https://github.com/tginsberg/junit5-system-exit/issues/20): Multiple calls to `System.exit()` do not always report the first exit status code.
 
 ### 2.0.0
 - Remove terminally deprecated `SecurityManager` approach for preventing `System.exit()` calls.

--- a/src/main/java/com/ginsberg/junit/exit/agent/AgentSystemExitHandlerStrategy.java
+++ b/src/main/java/com/ginsberg/junit/exit/agent/AgentSystemExitHandlerStrategy.java
@@ -39,7 +39,7 @@ public class AgentSystemExitHandlerStrategy implements ExitPreventerStrategy {
             if (firstExitStatusCode == null) {
                 firstExitStatusCode = status;
             }
-            throw new SystemExitPreventedException(status);
+            throw new SystemExitPreventedException(firstExitStatusCode);
         } else {
             System.exit(status);
         }

--- a/src/test/java/com/ginsberg/junit/exit/assertions/SystemExitAssertionTest.java
+++ b/src/test/java/com/ginsberg/junit/exit/assertions/SystemExitAssertionTest.java
@@ -102,6 +102,18 @@ class SystemExitAssertionTest {
         }
     }
 
+    @Test
+    void multipleCallsToExit() {
+        assertThatCallsSystemExit(() -> {
+            try {
+                System.exit(42);
+                System.exit(1);
+            } catch (final Exception e) {
+                System.exit(2);
+            }
+        }).withExitCode(42);
+    }
+
     private void justExit() {
         System.exit(42);
     }


### PR DESCRIPTION
When calling `System.exit()` more than once (something that really only makes sense in the context of a test that prevents exits), only the first exit code should be reported.